### PR TITLE
feat(db): implement ZDIFFSTORE command

### DIFF
--- a/src/server/zset_family.h
+++ b/src/server/zset_family.h
@@ -133,6 +133,7 @@ class ZSetFamily {
   static void ZScan(CmdArgList args, const CommandContext& cmd_cntx);
   static void ZUnion(CmdArgList args, const CommandContext& cmd_cntx);
   static void ZUnionStore(CmdArgList args, const CommandContext& cmd_cntx);
+  static void ZDiffStore(CmdArgList args, const CommandContext& cmd_cntx);
 };
 
 }  // namespace dfly

--- a/tests/fakeredis/test/test_mixins/test_sortedset_commands.py
+++ b/tests/fakeredis/test/test_mixins/test_sortedset_commands.py
@@ -1155,7 +1155,6 @@ def test_zrandemember(r: redis.Redis):
     assert len(r.zrandmember("a", -10)) == 10
 
 
-@pytest.mark.unsupported_server_types("dragonfly")
 def test_zdiffstore(r: redis.Redis):
     r.zadd("a", {"a1": 1, "a2": 2, "a3": 3})
     r.zadd("b", {"a1": 1, "a2": 2})


### PR DESCRIPTION
Implement the ZDIFFSTORE command for sorted sets, which computes the difference between multiple sorted sets and stores the result in a new key.



Seems To be a not common bug in  ZDiffInternal() regarding  synchronization of fetching maps data from shards. Using instead   Execute(cb, true); caused deadlock.

Closes #3887